### PR TITLE
Ignore flush on empty buffer

### DIFF
--- a/batcher.go
+++ b/batcher.go
@@ -68,6 +68,10 @@ func (b *batcher) Run(ctx context.Context) {
 }
 
 func (b *batcher) Flush(ctx context.Context) error {
+	if len(b.buf) == 0 {
+		return nil
+	}
+
 	b.mux.Lock()
 	defer b.mux.Unlock()
 

--- a/batcher_test.go
+++ b/batcher_test.go
@@ -127,25 +127,46 @@ func TestBatcher_Error(t *testing.T) {
 }
 
 func TestBatcher_Flush(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+	t.Run("one time", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
 
-	b := New(100,
-		time.Minute,
-		func(_ context.Context, v []interface{}) error {
-			require.Len(t, v, 1)
-			return nil
-		},
-	)
-	b.Run(ctx)
+		b := New(100,
+			time.Minute,
+			func(_ context.Context, v []interface{}) error {
+				require.Len(t, v, 1)
+				return nil
+			},
+		)
+		b.Run(ctx)
 
-	var err error
+		var err error
 
-	err = b.Push(ctx, nil)
-	require.NoError(t, err)
+		err = b.Push(ctx, nil)
+		require.NoError(t, err)
 
-	err = b.Flush(ctx)
-	require.NoError(t, err)
+		err = b.Flush(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("ignores empty buffer", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		b := New(100,
+			time.Minute,
+			func(_ context.Context, v []interface{}) error {
+				require.Fail(t, "flush should not be called")
+				return nil
+			},
+		)
+		b.Run(ctx)
+
+		var err error
+
+		err = b.Flush(ctx)
+		require.NoError(t, err)
+	})
 }
 
 func TestBatcher_WithBuffer(t *testing.T)  {


### PR DESCRIPTION
Ignore callback if the buffer is empty. Loop works in the same way, it ignores callback if the buffer is empty